### PR TITLE
basic phone number validation - to avoid calling doPhoneNumberLookup API

### DIFF
--- a/pages/dodaj-unos.js
+++ b/pages/dodaj-unos.js
@@ -110,6 +110,10 @@ export default function NewEntry({ itemTags }) {
 
   const handlePhoneNumberInput = async(value) => {
     const transposedNumber = (value[0] === '0') ? value.substring(1) : value;
+    if (transposedNumber.length < 2+6) { // basic validation - to avoid calling doPhoneNumberLookup API for invalid phone numbers (saving donated resources)
+      setNumberIsValid(false)
+      return
+    }
     const phoneNumberCheck = await doPhoneNumberLookup(`385${transposedNumber}`);
     if (phoneNumberCheck.results[0].status.groupName === 'DELIVERED') {
       setNumberIsValid(true)


### PR DESCRIPTION
basic phone number validation - to avoid calling doPhoneNumberLookup API for invalid phone numbers (saving donated resources)